### PR TITLE
pathlib is already in Python since 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='markgraham539@gmail.com',
     license="MIT",
     python_requires='>=3.7',
-    install_requires=['construct','imageio','natsort','numpy','opencv-python','pydicom','six','matplotlib','imageio-ffmpeg', 'pylibjpeg', 'pathlib', 'h5py'],
+    install_requires=['construct','imageio','natsort','numpy','opencv-python','pydicom','six','matplotlib','imageio-ffmpeg', 'pylibjpeg', 'h5py'],
     packages=find_packages(),
     include_package_data=True
 )


### PR DESCRIPTION
Installing old pathlib will create conflict for poetry maintenance.