### PR TITLE
Update fda.py to get all locations for a tag

### DIFF
--- a/oct_converter/readers/fda.py
+++ b/oct_converter/readers/fda.py
@@ -83,7 +83,11 @@ class FDA(object):
                     chunk_size = np.fromstring(f.read(4), dtype=np.uint32)[0]
                     chunk_location = f.tell()
                     f.seek(chunk_size, 1)
-                    chunk_dict[chunk_name] = [chunk_location, chunk_size]
+                    # Add this to get all locations - a tag can occur more than once (e.g. @CONTOUR_INFO)
+                    if chunk_name in chunk_dict:
+                        chunk_dict[chunk_name] += [(chunk_location, chunk_size)]
+                    else:
+                        chunk_dict[chunk_name] = [(chunk_location, chunk_size)]
         print('File {} contains the following chunks:'.format(self.filepath))
         for key in chunk_dict.keys():
             print(key)


### PR DESCRIPTION
Chunk names or tags can occur more than once. The function get_list_of_file_chunks do not take this into account as far as I see.