### PR TITLE
Adding support for custom slice dimension in Zeiss .img files

### DIFF
--- a/oct_converter/readers/img.py
+++ b/oct_converter/readers/img.py
@@ -17,7 +17,7 @@ class IMG(object):
         if not self.filepath.exists():
             raise FileNotFoundError(self.filepath)
 
-    def read_oct_volume(self, interlaced=False):
+    def read_oct_volume(self, rows=1024, cols=512, interlaced=False):
         """Reads OCT data.
         Args:
             interlaced (bool): Determines whether data needs to be de-interlaced.
@@ -29,17 +29,17 @@ class IMG(object):
             volume = np.frombuffer(
                 f.read(), dtype=np.uint8
             )  # np.fromstring() gives numpy depreciation warning
-            num_slices = len(volume) // (1024 * 512)
-            volume = volume.reshape((1024, 512, num_slices), order="F")
+            num_slices = len(volume) // (rows * cols)
+            volume = volume.reshape((rows, cols, num_slices), order="F")
             if interlaced:
                 shape = volume.shape
                 interlaced = np.zeros((int(shape[0] / 2), shape[1], shape[2] * 2))
-                interlaced[..., 0::2] = volume[:512, ...]
-                interlaced[..., 1::2] = volume[512:, ...]
+                interlaced[..., 0::2] = volume[:cols, ...]
+                interlaced[..., 1::2] = volume[cols:, ...]
                 interlaced = np.rot90(interlaced, axes=(0, 1))
                 volume = interlaced
 
         oct_volume = OCTVolumeWithMetaData(
             [volume[:, :, i] for i in range(volume.shape[2])]
         )
-        return oct_volume
+        return oct_volume, num_slices

--- a/oct_converter/readers/img.py
+++ b/oct_converter/readers/img.py
@@ -20,6 +20,8 @@ class IMG(object):
     def read_oct_volume(self, rows=1024, cols=512, interlaced=False):
         """Reads OCT data.
         Args:
+            rows (int): Can be used to specify a custom row dimension of the image slice. Defaults to 1024 pixels if not specified.
+            cols (int): Can be used to specify a custom column dimension of the image slice. Defaults to 512 pixels if not specified.
             interlaced (bool): Determines whether data needs to be de-interlaced.
 
             Returns:
@@ -42,4 +44,4 @@ class IMG(object):
         oct_volume = OCTVolumeWithMetaData(
             [volume[:, :, i] for i in range(volume.shape[2])]
         )
-        return oct_volume, num_slices
+        return oct_volume


### PR DESCRIPTION
I came across Zeiss *img files from a scanner that were of a different dimension than the ones supported in the code (default 1024, 512). 
To cater for different dimensions I have added a custom rows and cols argument in the `img.py` function. 
Custom A custom row, col value can be provided when calling the function for reading the img files (but defaults to 1024, 500 if nothing provided).

The function also returns the number of slices that are detected after reshaping, which is useful to confirm the conversion if the original number of slices are know. 


