### PR TITLE
fix poct header decoding error handling and acquisition date conversion

### DIFF
--- a/oct_converter/dicom/dicom.py
+++ b/oct_converter/dicom/dicom.py
@@ -201,11 +201,7 @@ def write_opt_dicom(
     ds.ImageType = ["DERIVED", "SECONDARY"]
     ds.SamplesPerPixel = 1
     if meta.series_info.acquisition_date:
-        # Convert string to datetime object
-        input_datetime = datetime.strptime(
-            meta.series_info.acquisition_date, "%Y-%m-%d %H:%M:%S"
-        )
-        ds.AcquisitionDateTime = input_datetime.strftime("%Y%m%d%H%M%S.%f")
+        ds.AcquisitionDateTime =  meta.series_info.acquisition_date.strftime("%Y%m%d%H%M%S.%f")
     else:
         ds.AcquisitionDateTime = ""
 

--- a/oct_converter/readers/boct.py
+++ b/oct_converter/readers/boct.py
@@ -8,7 +8,7 @@ from typing import BinaryIO
 
 import h5py
 import numpy as np
-from construct import Struct
+from construct import Struct, StringError
 from numpy.typing import NDArray
 
 from oct_converter.exceptions import InvalidOCTReaderError
@@ -39,7 +39,7 @@ class BOCT(object):
     def _validate(self, path: Path) -> bool:
         try:
             self.header_structure.parse_file(path)
-        except UnicodeDecodeError:
+        except StringError:
             raise InvalidOCTReaderError(
                 "OCT header does not match Bioptigen .OCT format. Did you mean to use Optovue .oct (POCT)?"
             )


### PR DESCRIPTION
Fixes discussed in https://github.com/marksgraham/OCT-Converter/issues/139
Two fixes : 
- Error handling when parsing an Optovue poct : construct raises a StringError when parsing an Optovue poct but the current behavior is to expect a UnicodeDecodeError.

- The acquisition date conversion is redundant. It seems to me that acquisition_date in SeriesMeta is already a datetime object, therefore the conversion in write_opt_dicom raises an error. I may be missing something because this fix is basically just reverting this previous commit https://github.com/marksgraham/OCT-Converter/commit/cbd5f00587d0b800a6057b52180a2373e75db6af. I was only able to test this on Optovue .OCT files.