### PR TITLE
E2E dicom and metadata updates

### DIFF
--- a/oct_converter/dicom/dicom.py
+++ b/oct_converter/dicom/dicom.py
@@ -203,7 +203,9 @@ def write_opt_dicom(
     ds.ImageType = ["DERIVED", "SECONDARY"]
     ds.SamplesPerPixel = 1
     if meta.series_info.acquisition_date:
-        ds.AcquisitionDateTime =  meta.series_info.acquisition_date.strftime("%Y%m%d%H%M%S.%f")
+        ds.AcquisitionDateTime = meta.series_info.acquisition_date.strftime(
+            "%Y%m%d%H%M%S.%f"
+        )
     else:
         ds.AcquisitionDateTime = ""
 
@@ -389,7 +391,7 @@ def create_dicom_from_oct(
     diskbuffered: bool = False,
     extract_scan_repeats: bool = False,
     scalex: float = 0.01,
-    slice_thickness: float = 0.05
+    slice_thickness: float = 0.05,
 ) -> list:
     """Creates a DICOM file with the data parsed from
     the input file.

--- a/oct_converter/dicom/metadata.py
+++ b/oct_converter/dicom/metadata.py
@@ -96,6 +96,9 @@ class SeriesMeta:
     acquisition_date: t.Optional[datetime.datetime] = None
     # Anatomy
     opt_anatomy: OPTAnatomyStructure = OPTAnatomyStructure.Unspecified
+    # Scan
+    protocol: str = ""
+    description: str = ""
 
 
 @dataclasses.dataclass

--- a/oct_converter/image_types/fundus.py
+++ b/oct_converter/image_types/fundus.py
@@ -35,7 +35,7 @@ class FundusImageWithMetaData(object):
         image_id: str | None = None,
         patient_dob: str | None = None,
         metadata: dict | None = None,
-        pixel_spacing: list[float] | None = None
+        pixel_spacing: list[float] | None = None,
     ) -> None:
         self.image = image
         self.laterality = laterality

--- a/oct_converter/image_types/fundus.py
+++ b/oct_converter/image_types/fundus.py
@@ -23,6 +23,8 @@ class FundusImageWithMetaData(object):
         patient_id: patient ID.
         image_id: image ID.
         DOB: patient date of birth.
+        metadata: all metadata parsed from the original file.
+        pixel_spacing: [x, y] pixel spacing in mm
     """
 
     def __init__(
@@ -33,6 +35,7 @@ class FundusImageWithMetaData(object):
         image_id: str | None = None,
         patient_dob: str | None = None,
         metadata: dict | None = None,
+        pixel_spacing: list[float] | None = None
     ) -> None:
         self.image = image
         self.laterality = laterality
@@ -40,6 +43,7 @@ class FundusImageWithMetaData(object):
         self.image_id = image_id
         self.DOB = patient_dob
         self.metadata = metadata
+        self.pixel_spacing = pixel_spacing
 
     def save(self, filepath: str | Path) -> None:
         """Saves fundus image.

--- a/oct_converter/readers/binary_structs/e2e_binary.py
+++ b/oct_converter/readers/binary_structs/e2e_binary.py
@@ -6,8 +6,10 @@ from construct import (
     Int32sn,
     Int32un,
     Int64un,
+    Float64l,
     PaddedString,
     Struct,
+    this,
 )
 
 # Mostly based on description of .e2e file format here:
@@ -77,7 +79,9 @@ patient_id_structure = Struct(
     "patient_id" / PaddedString(25, "ascii"),
 )
 lat_structure = Struct(
-    "unknown" / Array(14, Int8un), "laterality" / Int8un, "unknown2" / Int8un
+    "unknown" / Array(14, Int8un),
+    "laterality" / PaddedString(1, "ascii"),
+    "unknown2" / Int8un,
 )
 contour_structure = Struct(
     "unknown0" / Int32un,
@@ -113,4 +117,103 @@ bscan_metadata = Struct(
     "acquisitionTime" / Int64un,
     "numAve" / Int32un,
     "imgQuality" / Float32l,
+)
+
+# Chunk 7: Eye Data (libE2E)
+eye_data = Struct(
+    "eyeSide" / PaddedString(1, "ascii"),
+    "iop_mmHg" / Float64l,
+    "refraction_dpt" / Float64l,
+    "c_curve_mm" / Float64l,
+    "vfieldMean" / Float64l,
+    "vfieldVar" / Float64l,
+    "cylinder_dpt" / Float64l,
+    "axis_deg" / Float64l,
+    "correctiveLens" / Int16un,
+    "pupilSize_mm" / Float64l,
+)
+
+# 9001 Device Name
+# Files examined have n_strings=3, string_size=256,
+# text=["Heidelberg Retina Angiograph", "HRA", ""]
+device_name = Struct(
+    "n_strings" / Int32un,
+    "string_size" / Int32un,
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+)
+
+# 9005 Examined Structure
+# Files examined have n_strings=1, string_size=256,
+# text=["Retina"]
+examined_structure = Struct(
+    "n_strings" / Int32un,
+    "string_size" / Int32un,
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+)
+
+# 9006 Scan Pattern
+# Files examined have n_strings=2, string_size=256,
+# and scan patterns including "OCT Art Volume", "Images", "OCT B-SCAN",
+# "3D Volume", "OCT Star Scan"
+scan_pattern = Struct(
+    "n_strings" / Int32un,
+    "string_size" / Int32un,
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+)
+
+# 9007 Enface Modality
+# Files examined have n_strings=2, string_size=256,
+# and modalities including ["Infra-Red", "IR"],
+# ["Fluroescein Angiography", "FA"], ["ICG Angiography", "ICGA"]
+enface_modality = Struct(
+    "n_strings" / Int32un,
+    "string_size" / Int32un,
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+)
+
+# 9008 OCT Modality
+# Files examined have n_strings=2, string_size=256, text=["OCT", "OCT"]
+oct_modality = Struct(
+    "n_strings" / Int32un,
+    "string_size" / Int32un,
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+)
+
+# 10025 Localizer
+# From eyepy; "transform" is described as "Parameters of affine transformation"
+localizer = Struct(
+    "unknown" / Array(6, Float32l),
+    "windate" / Int32un,
+    "transform" / Array(6, Float32l),
+)
+
+# 3 seems to indicate the start of the chunk pattern
+# Examined files seem to have a mostly-regular pattern of 3, 2, ..., 5, 39
+# Both chunks 3 and 5 seem to include laterality info
+pre_data = Struct(
+    "unknown" / Int32un,
+    "laterality" / PaddedString(1, "ascii"),
+    # There's more here that I'm unsure of.
+    # There seems to be an "ART" in this chunk.
+)
+
+# 39 has some time zone data
+time_data = Struct(
+    "unknown" / Array(46, Int32un),
+    "timezone1" / PaddedString(66, "u16"),
+    "unknown2" / Array (9, Int16un),
+    "timezone2" / PaddedString(66, "u16"),
+    # There's more in this chunk (possibly datetimes, given tz)
+    # and the chunk size varies.
+)
+
+# 52, 54, 1000, 1001 seem to be UIDs with padded strings
+# 1000 may be StudyInstanceUID
+uid_data = Struct(
+    "uid" / PaddedString(64,"ascii")
+)
+
+# 1007 padded string with a brand name
+unknown_data = Struct(
+    "unknown" / PaddedString(64,"ascii")
 )

--- a/oct_converter/readers/binary_structs/e2e_binary.py
+++ b/oct_converter/readers/binary_structs/e2e_binary.py
@@ -1,12 +1,12 @@
 from construct import (
     Array,
     Float32l,
+    Float64l,
     Int8un,
     Int16un,
     Int32sn,
     Int32un,
     Int64un,
-    Float64l,
     PaddedString,
     Struct,
     this,
@@ -139,7 +139,7 @@ eye_data = Struct(
 device_name = Struct(
     "n_strings" / Int32un,
     "string_size" / Int32un,
-    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16")),
 )
 
 # 9005 Examined Structure
@@ -148,7 +148,7 @@ device_name = Struct(
 examined_structure = Struct(
     "n_strings" / Int32un,
     "string_size" / Int32un,
-    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16")),
 )
 
 # 9006 Scan Pattern
@@ -158,7 +158,7 @@ examined_structure = Struct(
 scan_pattern = Struct(
     "n_strings" / Int32un,
     "string_size" / Int32un,
-    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16")),
 )
 
 # 9007 Enface Modality
@@ -168,7 +168,7 @@ scan_pattern = Struct(
 enface_modality = Struct(
     "n_strings" / Int32un,
     "string_size" / Int32un,
-    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16")),
 )
 
 # 9008 OCT Modality
@@ -176,7 +176,7 @@ enface_modality = Struct(
 oct_modality = Struct(
     "n_strings" / Int32un,
     "string_size" / Int32un,
-    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16"))
+    "text" / Array(this.n_strings, PaddedString(this.string_size, "u16")),
 )
 
 # 10025 Localizer
@@ -201,7 +201,7 @@ pre_data = Struct(
 time_data = Struct(
     "unknown" / Array(46, Int32un),
     "timezone1" / PaddedString(66, "u16"),
-    "unknown2" / Array (9, Int16un),
+    "unknown2" / Array(9, Int16un),
     "timezone2" / PaddedString(66, "u16"),
     # There's more in this chunk (possibly datetimes, given tz)
     # and the chunk size varies.
@@ -209,11 +209,7 @@ time_data = Struct(
 
 # 52, 54, 1000, 1001 seem to be UIDs with padded strings
 # 1000 may be StudyInstanceUID
-uid_data = Struct(
-    "uid" / PaddedString(64,"ascii")
-)
+uid_data = Struct("uid" / PaddedString(64, "ascii"))
 
 # 1007 padded string with a brand name
-unknown_data = Struct(
-    "unknown" / PaddedString(64,"ascii")
-)
+unknown_data = Struct("unknown" / PaddedString(64, "ascii"))

--- a/oct_converter/readers/boct.py
+++ b/oct_converter/readers/boct.py
@@ -8,7 +8,7 @@ from typing import BinaryIO
 
 import h5py
 import numpy as np
-from construct import Struct, StringError
+from construct import StringError, Struct
 from numpy.typing import NDArray
 
 from oct_converter.exceptions import InvalidOCTReaderError

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -262,7 +262,7 @@ class E2E(object):
                                 else:
                                     volume_array_dict_additional[volume_string] = [
                                         image
-                                    ]               
+                                    ]
 
             contour_data = {}
             for volume_id, contours in contour_dict.items():
@@ -516,7 +516,7 @@ class E2E(object):
                     raw = f.read(20)
                     image_data = e2e_binary.image_structure.parse(raw)
                     metadata["image_data"].append(_convert_to_dict(image_data))
-                
+
                 elif chunk.type == 9001:  # device data ("Heidelberg Retina Angiograph")
                     raw = f.read(chunk.size)
                     device_data = e2e_binary.device_name.parse(raw)
@@ -547,38 +547,44 @@ class E2E(object):
                     oct_modality = e2e_binary.oct_modality.parse(raw)
                     if image_string not in metadata["oct_modality"]:
                         metadata["oct_modality"][image_string] = oct_modality.text[0]
-                
+
                 elif chunk.type == 10025:
                     raw = f.read(chunk.size)
                     localizer = e2e_binary.localizer.parse(raw)
                     metadata["localizer"].append(_convert_to_dict(localizer))
-                
+
                 elif chunk.type == 7:  # eye data
                     raw = f.read(chunk.size)
                     eye_data = e2e_binary.eye_data.parse(raw)
                     metadata["eye_data"].append(_convert_to_dict(eye_data))
-                
+
                 elif chunk.type == 39:  # time zone, possibly timestamps
                     raw = f.read(chunk.size)
                     time_data = e2e_binary.time_data.parse(raw)
                     metadata["time_data"].append(_convert_to_dict(time_data))
-                
+
                 elif chunk.type in [52, 54, 1000, 1001]:  # various UIDs
                     raw = f.read(chunk.size)
                     uid_data = e2e_binary.uid_data.parse(raw)
-                    metadata["uid_data"].append({chunk.type: _convert_to_dict(uid_data)})
-                
+                    metadata["uid_data"].append(
+                        {chunk.type: _convert_to_dict(uid_data)}
+                    )
+
                 # Chunks 1005, 1006, and 1007 seem to contain strings of device data,
                 # including some servicers and distributors and other entities,
                 # but not always in the same order.
-                elif chunk.type in [1005, 1006]: 
+                elif chunk.type in [1005, 1006]:
                     raw = f.read(chunk.size)
-                    metadata["additional_device_data"].append({chunk.type: raw.decode()})
+                    metadata["additional_device_data"].append(
+                        {chunk.type: raw.decode()}
+                    )
 
                 elif chunk.type == 1007:
                     raw = f.read(chunk.size)
                     unknown_data = e2e_binary.unknown_data.parse(raw)
-                    metadata["additional_device_data"].append({chunk.type: _convert_to_dict(unknown_data)})
+                    metadata["additional_device_data"].append(
+                        {chunk.type: _convert_to_dict(unknown_data)}
+                    )
 
         return metadata
 

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -415,6 +415,7 @@ class E2E(object):
                         if key in laterality_dict.keys()
                         else None,
                         metadata=metadata,
+                        pixel_spacing=[scalex, scalex],
                     )
                 )
 


### PR DESCRIPTION
Hi Mark!

I've been working a bit more on E2E to DICOM and have a few updates...

DICOM-specific
- Added ProtocolName and SeriesDescription tags to hold enface modality and scan pattern
- Moved Fundus PixelSpacing to first-level tag 
- Added red/green/blue to ImageType depending on enface type
- Exposed scalex and slice_thickness as args that can be passed. (I'm still trying to figure these out, especially scalex, but... This at least allows the user to set these values correctly if known.)

Additional E2E updates
- Adjusted laterality logic (Had a test file where the previous logic didn't work for the first slice of the second eye scan)
- Adjusted "laterality" from `Int8un` to `ascii`, because it's really just stored as R or L in the E2E.
- Fleshed out more metadata chunks, tried to comment in a way that points out some great potential spots for more investigation
	* Chunk 7: Eye Data (thanks to libE2E). The test files I had only have corneal curve(`c_curve_mm`) and 0s for the other fields, unfortunately
	* Chunk 9001: Device Name (in my test files, always ["Heidelberg Retina Angiograph", "HRA", ""])
	* Chunk 9005: Examined Structure (in my test files, always "Retina")
	* Chunk 9006: Scan Pattern (found values of "OCT Art Volume", "Images", "OCT B-Scan", "3D Volume", "OCT Star Scan")
	* Chunk 9007: Enface Modality (found ["Infra-Red", "IR"], ["Fluroescein Angiography", "FA"], ["ICG Angiography", "ICGA"])
	* Chunk 9008: OCT Modality (Found ["OCT", "OCT"])
	* Chunk 10025: Localizer (thanks to eyepy). I'm really hoping to figure out this chunk further...
	* Chunk 3: I've listed this as `pre_data` because it typically seems to start each series of chunks. It definitely has laterality, and there's an "ART" a little ways in, but I haven't been able to decode further.
	* Chunk 39: Time... The first thing that jumped out at me were timezones (Like "Eastern Standard Time"). I think there's likely more here. Timestamps would make the most sense, along with regional information.
	* Chunk 52, 54, 1000, 1001 (and maybe more, it seems like there's some variation that I haven't figured out) are UIDs
	* Chunk 1007 seems to be a padded string with a brand name, potentially the supplier of the device, but I'm not certain.


I'd still *really* like to find how to calculate scalex (wouldn't we all!), and am still slowly working on that, mostly running into a lot of places where there isn't useful information for that particular puzzle piece. Let me know if there are any changes you'd like made!