### PR TITLE
Update E2E acquisition_date to be datetime like the other readers

### DIFF
--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 import warnings
 from collections import defaultdict
-from datetime import date
+from datetime import date, datetime
 from itertools import chain
 from pathlib import Path
 
@@ -160,9 +160,9 @@ class E2E(object):
                         - secToUnixEpechFromWindowsTicks
                     )
                     utc_time = time.gmtime(unixtime)
-                    utc_time_string = time.strftime("%Y-%m-%d %H:%M:%S", utc_time)
+                    dt_time = datetime.fromtiemstamp(time.mktime(utc_time))
                     if self.acquisition_date is None:
-                        self.acquisition_date = utc_time_string
+                        self.acquisition_date = dt_time
                     if self.pixel_spacing is None:
                         # scaley found, x and z not yet found in file
                         self.pixel_spacing = [

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -160,7 +160,7 @@ class E2E(object):
                         - secToUnixEpechFromWindowsTicks
                     )
                     utc_time = time.gmtime(unixtime)
-                    dt_time = datetime.fromtiemstamp(time.mktime(utc_time))
+                    dt_time = datetime.fromtimestamp(time.mktime(utc_time))
                     if self.acquisition_date is None:
                         self.acquisition_date = dt_time
                     if self.pixel_spacing is None:


### PR DESCRIPTION
All of the readers currently store acquisition_date as a datetime; E2E storing this as a string makes things a bit sticky for DICOM conversion. The other option would be to switch all of the readers to store these values as strings and change the DICOM metadata part to expect strings.