### PR TITLE
E2E UID and birthdate error handling

### DIFF
--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -138,14 +138,24 @@ class E2E(object):
                         self.sex = patient_data.sex
                         self.first_name = patient_data.first_name
                         self.surname = patient_data.surname
-                        julian_birthdate = (patient_data.birthdate / 64) - 14558805
-                        self.birthdate = self.julian_to_ymd(julian_birthdate)
-                        # TODO: There are conflicting ideas of how to parse E2E's birthdate
-                        # https://bitbucket.org/uocte/uocte/wiki/Heidelberg%20File%20Format suggests the above,
-                        # whereas https://github.com/neurodial/LibE2E/blob/master/E2E/dataelements/patientdataelement.cpp
-                        # suggests that DOB is given as a Windows date. Neither option seems accurate to
-                        # test files with known-correct birthdates. More investigation is needed.
                         self.patient_id = patient_data.patient_id
+                        if len(str(patient_data.birthdate)) == 8:
+                            # Encountered a file where birthdate had been stored as YYYYMMDD,
+                            # this is an attempt to catch that.
+                            self.birthdate = str(patient_data.birthdate)
+                        else:
+                            try:
+                                julian_birthdate = (patient_data.birthdate / 64) - 14558805
+                                self.birthdate = self.julian_to_ymd(julian_birthdate)
+                                # TODO: There are conflicting ideas of how to parse E2E's birthdate
+                                # https://bitbucket.org/uocte/uocte/wiki/Heidelberg%20File%20Format suggests the above,
+                                # whereas https://github.com/neurodial/LibE2E/blob/master/E2E/dataelements/patientdataelement.cpp
+                                # suggests that DOB is given as a Windows date. Neither option seems accurate to
+                                # test files with known-correct birthdates. More investigation is needed.
+                            except ValueError:
+                                # If the julian_to_ymd function cannot parse it into a date obj,
+                                # it throws a ValueError
+                                self.birthdate = None
                     except Exception:
                         pass
 

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -6,9 +6,9 @@ from collections import defaultdict
 from datetime import date, datetime
 from itertools import chain
 from pathlib import Path
-from construct.core import StreamError
 
 import numpy as np
+from construct.core import StreamError
 
 from oct_converter.image_types import FundusImageWithMetaData, OCTVolumeWithMetaData
 from oct_converter.readers.binary_structs import e2e_binary
@@ -145,7 +145,9 @@ class E2E(object):
                             self.birthdate = str(patient_data.birthdate)
                         else:
                             try:
-                                julian_birthdate = (patient_data.birthdate / 64) - 14558805
+                                julian_birthdate = (
+                                    patient_data.birthdate / 64
+                                ) - 14558805
                                 self.birthdate = self.julian_to_ymd(julian_birthdate)
                                 # TODO: There are conflicting ideas of how to parse E2E's birthdate
                                 # https://bitbucket.org/uocte/uocte/wiki/Heidelberg%20File%20Format suggests the above,

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from datetime import date, datetime
 from itertools import chain
 from pathlib import Path
+from construct.core import StreamError
 
 import numpy as np
 
@@ -564,11 +565,14 @@ class E2E(object):
                     metadata["time_data"].append(_convert_to_dict(time_data))
 
                 elif chunk.type in [52, 54, 1000, 1001]:  # various UIDs
-                    raw = f.read(chunk.size)
-                    uid_data = e2e_binary.uid_data.parse(raw)
-                    metadata["uid_data"].append(
-                        {chunk.type: _convert_to_dict(uid_data)}
-                    )
+                    try:
+                        raw = f.read(chunk.size)
+                        uid_data = e2e_binary.uid_data.parse(raw)
+                        metadata["uid_data"].append(
+                            {chunk.type: _convert_to_dict(uid_data)}
+                        )
+                    except StreamError:
+                        pass
 
                 # Chunks 1005, 1006, and 1007 seem to contain strings of device data,
                 # including some servicers and distributors and other entities,


### PR DESCRIPTION
A couple of small fixes to address problems that have arisen with various new E2E files I've received...

1) Encountered an E2E file where a UID chunk was throwing a `StreamError` because the chunk size seemed to be incorrect (ran out of bytes to parse). I've wrapped this chunk in a try except so that it doesn't fail here.

2) Encountered an E2E file where the birthdate was saved as YYYYMMDD (had been de-identified by the Heidelberg software user to be 19000101). Now I'm *even more* confused about how Heidelberg is storing this value, since all the other files I've seen are definitely not storing birthdate as YYYYMMDD. There might be a smarter way to toggle between birthdate forms, whether it's YYYMMDD or Julian or Windows dating or something completely different, but this at least is a simple solution to catch when the value would otherwise throw an error during `julian_to_ymd()`...

Thanks much, and let me know if you have any questions or suggestions!