### PR TITLE
E2E slice ordering adjustment

### DIFF
--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -206,7 +206,7 @@ class E2E(object):
                         volume_string = "{}_{}_{}".format(
                             chunk.patient_db_id, chunk.study_id, chunk.series_id
                         )
-                        slice_id = int(chunk.slice_id / 2) - 1
+                        slice_id = int(chunk.slice_id / 2) # - 1
                         contour_name = f"contour{contour_data.id}"
                         try:
                             raw_volume = np.frombuffer(
@@ -264,7 +264,7 @@ class E2E(object):
 
                             if volume_string in volume_array_dict.keys():
                                 volume_array_dict[volume_string][
-                                    int(chunk.slice_id / 2) - 1
+                                    int(chunk.slice_id / 2) # - 1
                                 ] = image
                             else:
                                 # try to capture these additional images

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -206,7 +206,7 @@ class E2E(object):
                         volume_string = "{}_{}_{}".format(
                             chunk.patient_db_id, chunk.study_id, chunk.series_id
                         )
-                        slice_id = int(chunk.slice_id / 2) # - 1
+                        slice_id = int(chunk.slice_id / 2)
                         contour_name = f"contour{contour_data.id}"
                         try:
                             raw_volume = np.frombuffer(
@@ -264,7 +264,7 @@ class E2E(object):
 
                             if volume_string in volume_array_dict.keys():
                                 volume_array_dict[volume_string][
-                                    int(chunk.slice_id / 2) # - 1
+                                    int(chunk.slice_id / 2)
                                 ] = image
                             else:
                                 # try to capture these additional images


### PR DESCRIPTION
It was pointed out to me on a few test files that the converted output had the first slice as last within each volume, and I noticed that the logic utilized for slice ordering `int(chunk.slice_id / 2) - 1` becomes -1 if `chunk.slice_id` is 0, which was happening with the test E2E files.

Are there other files that you've encountered where the `- 1` is needed? Removing it seems like a simple solution, but if some files need that last bit of the equation, then there might need to be more logic around whether or not to do the subtraction... 