### PR TITLE
Pydicom updates

### DIFF
--- a/oct_converter/dicom/dicom.py
+++ b/oct_converter/dicom/dicom.py
@@ -249,7 +249,9 @@ def write_opt_dicom(
         per_frame.append(frame_fgs)
     ds.PerFrameFunctionalGroupsSequence = per_frame
     ds.PixelData = pixel_data.tobytes()
-    ds.save_as(filepath, implicit_vr=False, little_endian=True, enforce_file_format=True)
+    ds.save_as(
+        filepath, implicit_vr=False, little_endian=True, enforce_file_format=True
+    )
     return filepath
 
 
@@ -312,7 +314,9 @@ def write_fundus_dicom(
     ds.Columns = pixel_data.shape[1]
 
     ds.PixelData = pixel_data.tobytes()
-    ds.save_as(filepath, implicit_vr=False, little_endian=True, enforce_file_format=True)
+    ds.save_as(
+        filepath, implicit_vr=False, little_endian=True, enforce_file_format=True
+    )
     return filepath
 
 
@@ -376,7 +380,9 @@ def write_color_fundus_dicom(
     ds.Columns = pixel_data.shape[1]
 
     ds.PixelData = pixel_data.tobytes()
-    ds.save_as(filepath, implicit_vr=False, little_endian=True, enforce_file_format=True)
+    ds.save_as(
+        filepath, implicit_vr=False, little_endian=True, enforce_file_format=True
+    )
     return filepath
 
 

--- a/oct_converter/dicom/dicom.py
+++ b/oct_converter/dicom/dicom.py
@@ -46,8 +46,6 @@ def opt_base_dicom(filepath: Path) -> Dataset:
 
     # Create the FileDataset instance with file meta, preamble and empty DS
     ds = FileDataset(str(filepath), {}, file_meta=file_meta, preamble=b"\0" * 128)
-    ds.is_little_endian = True
-    ds.is_implicit_VR = False  # Explicit VR
     return ds
 
 
@@ -251,7 +249,7 @@ def write_opt_dicom(
         per_frame.append(frame_fgs)
     ds.PerFrameFunctionalGroupsSequence = per_frame
     ds.PixelData = pixel_data.tobytes()
-    ds.save_as(filepath)
+    ds.save_as(filepath, implicit_vr=False, little_endian=True, enforce_file_format=True)
     return filepath
 
 
@@ -314,7 +312,7 @@ def write_fundus_dicom(
     ds.Columns = pixel_data.shape[1]
 
     ds.PixelData = pixel_data.tobytes()
-    ds.save_as(filepath)
+    ds.save_as(filepath, implicit_vr=False, little_endian=True, enforce_file_format=True)
     return filepath
 
 
@@ -378,7 +376,7 @@ def write_color_fundus_dicom(
     ds.Columns = pixel_data.shape[1]
 
     ds.PixelData = pixel_data.tobytes()
-    ds.save_as(filepath)
+    ds.save_as(filepath, implicit_vr=False, little_endian=True, enforce_file_format=True)
     return filepath
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "natsort",
     "numpy",
     "opencv-python",
-    "pydicom",
+    "pydicom>3",
     "matplotlib",
     "imageio-ffmpeg",
     "h5py",


### PR DESCRIPTION
Hi Mark,

Noticed in a fresh repository install that the unconstrained pydicom dependency meant this was using pydicom 3.0.1, which has a few changes: `.is_little_endian` and `.is_implicit_VR` are now deprecated, with recommendation to use `.save_as()` args instead. Additionally, added `enforce_file_format=True` to make sure the DICOM File Meta is fully populated and compliant. The `enforce_file_format` arg is a breaking change between pydicom 2 and 3 - in 2, it's `write_like_original`, so I've also added a version constraint to pydicom in the pyproject.toml.

Thanks much!