### PR TITLE
De-interlace of .img images now working for any shape

### DIFF
--- a/oct_converter/readers/img.py
+++ b/oct_converter/readers/img.py
@@ -42,9 +42,10 @@ class IMG(object):
             volume = volume.reshape((rows, cols, num_slices), order="F")
             if interlaced:
                 shape = volume.shape
+                mid_height = shape[0] // 2
                 interlaced = np.zeros((int(shape[0] / 2), shape[1], shape[2] * 2))
-                interlaced[..., 0::2] = volume[:cols, ...]
-                interlaced[..., 1::2] = volume[cols:, ...]
+                interlaced[..., 0::2] = volume[:mid_height, ...]
+                interlaced[..., 1::2] = volume[mid_height:, ...]
                 interlaced = np.rot90(interlaced, axes=(0, 1))
                 volume = interlaced
 


### PR DESCRIPTION
The de-interlace block assumed cols == rows/2 (which was not the case for my Zeiss .img images). 

Now it will work for any image shape.