### PR TITLE
DICOM fundus SOPClassUID correction, small E2E polishing

### DIFF
--- a/oct_converter/dicom/dicom.py
+++ b/oct_converter/dicom/dicom.py
@@ -10,6 +10,7 @@ from construct import StreamError
 from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
 from pydicom.uid import (
     ExplicitVRLittleEndian,
+    OphthalmicPhotography16BitImageStorage,
     OphthalmicTomographyImageStorage,
     generate_uid,
 )
@@ -272,6 +273,7 @@ def write_fundus_dicom(
     ds = populate_manufacturer_info(ds, meta)
     ds = populate_opt_series(ds, meta)
     ds.Modality = "OP"
+    ds.SOPClassUID = OphthalmicPhotography16BitImageStorage
     ds = populate_ocular_region(ds, meta)
 
     ds.PixelSpacing = meta.image_geometry.pixel_spacing
@@ -337,6 +339,7 @@ def write_color_fundus_dicom(
     ds = populate_manufacturer_info(ds, meta)
     ds = populate_opt_series(ds, meta)
     ds.Modality = "OP"
+    ds.SOPClassUID = OphthalmicPhotography16BitImageStorage
     ds = populate_ocular_region(ds, meta)
 
     ds.PixelSpacing = meta.image_geometry.pixel_spacing

--- a/oct_converter/dicom/e2e_meta.py
+++ b/oct_converter/dicom/e2e_meta.py
@@ -159,7 +159,7 @@ def e2e_dicom_metadata(
         meta.series_info = e2e_series_meta(
             image.image_id,
             image.laterality,
-            None,
+            image.acquisition_date,
             image.metadata,
         )
         meta.image_geometry = e2e_image_geom(image.pixel_spacing)

--- a/oct_converter/image_types/fundus.py
+++ b/oct_converter/image_types/fundus.py
@@ -23,6 +23,7 @@ class FundusImageWithMetaData(object):
         patient_id: patient ID.
         image_id: image ID.
         DOB: patient date of birth.
+        acquisition_date: date and time of image acquisition.
         metadata: all metadata parsed from the original file.
         pixel_spacing: [x, y] pixel spacing in mm
     """
@@ -34,6 +35,7 @@ class FundusImageWithMetaData(object):
         patient_id: str | None = None,
         image_id: str | None = None,
         patient_dob: str | None = None,
+        acquisition_date: str | None = None,
         metadata: dict | None = None,
         pixel_spacing: list[float] | None = None,
     ) -> None:
@@ -42,6 +44,7 @@ class FundusImageWithMetaData(object):
         self.patient_id = patient_id
         self.image_id = image_id
         self.DOB = patient_dob
+        self.acquisition_date = acquisition_date
         self.metadata = metadata
         self.pixel_spacing = pixel_spacing
 

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -591,9 +591,12 @@ class E2E(object):
                     metadata["eye_data"].append(_convert_to_dict(eye_data))
 
                 elif chunk.type == 39:  # time zone, possibly timestamps
-                    raw = f.read(chunk.size)
-                    time_data = e2e_binary.time_data.parse(raw)
-                    metadata["time_data"].append(_convert_to_dict(time_data))
+                    try:
+                        raw = f.read(chunk.size)
+                        time_data = e2e_binary.time_data.parse(raw)
+                        metadata["time_data"].append(_convert_to_dict(time_data))
+                    except StreamError:
+                        pass
 
                 elif chunk.type in [52, 54, 1000, 1001]:  # various UIDs
                     try:

--- a/oct_converter/readers/e2e.py
+++ b/oct_converter/readers/e2e.py
@@ -440,6 +440,7 @@ class E2E(object):
                         laterality=laterality_dict[key]
                         if key in laterality_dict.keys()
                         else None,
+                        acquisition_date=self.acquisition_date,
                         metadata=metadata,
                         pixel_spacing=[scalex, scalex],
                     )


### PR DESCRIPTION
Hi Mark,

Another coworker and I have been sitting on a couple small polishing details that we've combined into one (still very small) MR. These changes:

* Correct fundus DICOM to SOPClassUID "OphthalmicPhotography16BitImageStorage" for accuracy
* Propagate `image.acquisition_date` more consistently in E2E files when available, including to fundus image
* In e2e.py, wrap parsing `chunk.type == 39` in a try except to prevent a `StreamError` encountered in a few E2E files

Please let me know if you have any questions, concerns, suggestions!
Thanks much,
Susannah