### PR TITLE
fix(dicom): fix FrameAnatomySequence nesting

### DIFF
--- a/oct_converter/dicom/dicom.py
+++ b/oct_converter/dicom/dicom.py
@@ -169,8 +169,10 @@ def opt_shared_functional_groups(ds: Dataset, meta: DicomMetadata) -> Dataset:
     shared_ds = [Dataset()]
     # Frame anatomy PS3.3 C.7.6.16.2.8
     shared_ds[0].FrameAnatomySequence = [Dataset()]
-    shared_ds[0].FrameAnatomySequence[0] = ds.AnatomicRegionSequence[0].copy()
     shared_ds[0].FrameAnatomySequence[0].FrameLaterality = meta.series_info.laterality
+    shared_ds[0].FrameAnatomySequence[0].AnatomicRegionSequence = [
+        ds.AnatomicRegionSequence[0].copy()
+    ]
     # Pixel Measures PS3.3 C.7.6.16.2.1
     shared_ds[0].PixelMeasuresSequence = [Dataset()]
     shared_ds[0].PixelMeasuresSequence[


### PR DESCRIPTION
Fix tags marked as missing/unexpected by [dicom-validator](https://github.com/pydicom/dicom-validator), e.g.:

```  
Module "Frame Anatomy":
  (5200,9229) (Shared Functional Groups Sequence) / (0020,9071) (Frame Anatomy Sequence):
    Tag (0008,0100) (Code Value) is unexpected
    Tag (0008,0102) (Coding Scheme Designator) is unexpected
    Tag (0008,0104) (Code Meaning) is unexpected
    Tag (0008,2218) (Anatomic Region Sequence) is missing
```