### PR TITLE
fix(dicom): fix invalid value for VR DS

### DIFF
--- a/oct_converter/dicom/dicom.py
+++ b/oct_converter/dicom/dicom.py
@@ -14,6 +14,7 @@ from pydicom.uid import (
     OphthalmicTomographyImageStorage,
     generate_uid,
 )
+from pydicom.valuerep import DSfloat
 
 from oct_converter.dicom.boct_meta import boct_dicom_metadata
 from oct_converter.dicom.e2e_meta import e2e_dicom_metadata
@@ -256,7 +257,7 @@ def write_opt_dicom(
         # Per Frame Functional Groups
         frame_fgs = Dataset()
         frame_fgs.PlanePositionSequence = [Dataset()]
-        ipp = [0, 0, i * meta.image_geometry.slice_thickness]
+        ipp = [0, 0, DSfloat(i * meta.image_geometry.slice_thickness, auto_format=True)]
         frame_fgs.PlanePositionSequence[0].ImagePositionPatient = ipp
         frame_fgs.FrameContentSequence = [Dataset()]
         frame_fgs.FrameContentSequence[0].InStackPositionNumber = i + 1


### PR DESCRIPTION
Fix tags marked with invalid values by [dicom-validator](https://github.com/pydicom/dicom-validator), e.g.:

```
Module "Plane Position (Patient)":
(5200,9230) (Per-Frame Functional Groups Sequence) / (0020,9113) (Plane Position Sequence):
  Tag (0020,0032) (Image Position (Patient)) has invalid value '0.30000000000000004' for VR DS
```